### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,10 @@ services:
       - POSTGRES_PASSWORD=${DB_PASSWORD}
       - POSTGRES_DB=${DB_NAME}
     volumes:
-      - rivm_db:/var/lib/postgresql/data  
+      - rivm_db:/var/lib/postgresql/data
+    env_file:
+      - .env
+    command: -p ${DB_PORT}  
 
   pgadmin:
     container_name: pgadmin


### PR DESCRIPTION
In the docker container, the db was running on the port 5432 by default, it wasn't picking up the custom port from the **.env** file.
As a fix, introduced some additional commands in the db service of docker-compose to add the port as a parameter to the postgres db command.
```
  db:
    container_name: postgresql_db
    image: postgres
    restart: always
    ports:
      - ${DB_PORT}:${DB_PORT}
    environment:
      - POSTGRES_USER=${DB_USER}
      - POSTGRES_PASSWORD=${DB_PASSWORD}
      - POSTGRES_DB=${DB_NAME}
    volumes:
      - rivm_db:/var/lib/postgresql/data
    env_file:
      - .env
    command: -p ${DB_PORT}

``` 
